### PR TITLE
Update opam file

### DIFF
--- a/dap.opam
+++ b/dap.opam
@@ -12,7 +12,7 @@ dev-repo: "git://git@github.com:hackwaly/ocaml-dap.git"
 doc: "https://hackwaly.github.io/ocaml-dap/"
 depends: [
   "ocaml" {>= "4.08"}
-  "dune" {build & >= "1.3"}
+  "dune" {>= "2.7"}
   "yojson"
   "ppx_here"
   "ppx_deriving"


### PR DESCRIPTION
- dune cannot be tagged build for forward dependencies reasons
- dune-project requires 2.7