### PR TITLE
Prepare for a new release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 4.12.x # minimum supported: library only (expect tests need >= 4.14)
+          # minimum supported: library only (expect tests need >= 4.14).
+          # full name + archive repo (below): < 4.11 lives in opam-repository-archive.
+          - ocaml-base-compiler.4.08.1
           - 4.14.x
           - 5.4.x
         include:
@@ -43,11 +45,15 @@ jobs:
         uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          # archive holds the pre-4.11 compilers; default must be listed explicitly.
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+            archive: https://github.com/ocaml/opam-repository-archive.git
 
       # debug_protocol.ml/.mli are code-generated at build time by
       # scripts/gen_protocol.js, which needs Node and the npm packages pinned
       # in yarn.lock (yargs, lodash). Only the test legs run a non-release
-      # `dune build` that re-invokes the generator; the 4.11 release build
+      # `dune build` that re-invokes the generator; the 4.08 release build
       # (`dune build -p dap`) ignores promoted rules and uses the committed
       # sources, so it needs neither Node nor the test dependencies.
       - name: Set up Node.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,4 @@ jobs:
 
       - name: Build and run tests
         if: ${{ matrix.run-tests }}
+        run: opam exec -- dune runtest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * *"
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.12.x # minimum supported: library only (expect tests need >= 4.14)
+          - 4.14.x
+          - 5.4.x
+        include:
+          # The expect-test harness uses the ppx_expect >= v0.16 `IO` API,
+          # which requires OCaml >= 4.14, so tests only run on these versions.
+          - ocaml-compiler: 4.14.x
+            run-tests: true
+          - ocaml-compiler: 5.4.x
+            run-tests: true
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          lfs: true # https://github.com/ocaml/setup-ocaml/issues/895#issuecomment-2477062336
+
+      - name: Set up OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      # debug_protocol.ml/.mli are code-generated at build time by
+      # scripts/gen_protocol.js, which needs Node and the npm packages pinned
+      # in yarn.lock (yargs, lodash). Only the test legs run a non-release
+      # `dune build` that re-invokes the generator; the 4.11 release build
+      # (`dune build -p dap`) ignores promoted rules and uses the committed
+      # sources, so it needs neither Node nor the test dependencies.
+      - name: Set up Node.js
+        if: ${{ matrix.run-tests }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install JS dependencies (protocol generator)
+        if: ${{ matrix.run-tests }}
+        run: yarn install --frozen-lockfile
+
+      - name: Install OCaml dependencies (with tests)
+        if: ${{ matrix.run-tests }}
+        run: opam install . --deps-only --with-test
+
+      - name: Install OCaml dependencies (library only)
+        run: opam install . --deps-only
+
+      - name: Build library
+        run: opam exec -- dune build -p dap
+
+      - name: Build and run tests
+        if: ${{ matrix.run-tests }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   (spec 1.71). Adds the `outputPresentation` field on `StartDebugging` and
   refreshes documentation across the generated types. Builds on the schema
   update and generator consolidation from hackwaly/ocaml-dap#3.
+- Generated the `arguments` field on the `restart` request
+  (`Restart_command.Arguments`) so it carries the latest launch/attach
+  configuration instead of an empty object.
 - Added Error_with_message exception.
 
 ## 1.0.6 2021-02-22

--- a/dap.opam
+++ b/dap.opam
@@ -11,21 +11,24 @@ bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
 dev-repo: "git+https://github.com/hackwaly/ocaml-dap.git"
 doc: "https://hackwaly.github.io/ocaml-dap/"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "4.12"}
   "dune" {>= "2.7"}
   "yojson"
-  "fmt"
   "ppx_here"
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "ppx_expect"
+  "ppx_expect" {with-test & >= v0.16}
   "lwt"
-  "lwt_ppx"
+  "lwt_ppx" {>= "2.0.1"}
   "lwt_react"
   "react"
   "angstrom"
   "angstrom-lwt-unix"
   "logs"
+  "fmt" {with-test}
+]
+conflicts: [
+  "result" {< "1.5"}
 ]
 build: [
   ["dune" "subst"] {pinned}

--- a/dap.opam
+++ b/dap.opam
@@ -11,7 +11,7 @@ bug-reports: "https://github.com/hackwaly/ocaml-dap/issues"
 dev-repo: "git+https://github.com/hackwaly/ocaml-dap.git"
 doc: "https://hackwaly.github.io/ocaml-dap/"
 depends: [
-  "ocaml" {>= "4.12"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.7"}
   "yojson"
   "ppx_here"

--- a/dap.opam
+++ b/dap.opam
@@ -17,7 +17,7 @@ depends: [
   "ppx_here"
   "ppx_deriving"
   "ppx_deriving_yojson"
-  "ppx_expect" {with-test & >= v0.16}
+  "ppx_expect" {with-test & >= "v0.16"}
   "lwt"
   "lwt_ppx" {>= "2.0.1"}
   "lwt_react"

--- a/src/debug_rpc/dune
+++ b/src/debug_rpc/dune
@@ -1,7 +1,5 @@
 (library
  (name debug_rpc)
  (public_name dap.rpc_lwt)
- (inline_tests)
- (preprocess
-  (pps ppx_expect ppx_deriving.make ppx_deriving_yojson lwt_ppx))
+ (preprocess (pps lwt_ppx))
  (libraries debug_protocol lwt lwt.unix angstrom angstrom.lwt-unix logs logs.lwt react))

--- a/src/debug_rpc_test/dune
+++ b/src/debug_rpc_test/dune
@@ -1,5 +1,9 @@
 (library
  (name debug_rpc_test)
+ ; The expect-test harness uses the ppx_expect >= v0.16 `IO` API, which needs
+ ; OCaml >= 4.14; disable the tests below that so `dune build` on 4.11 doesn't
+ ; require ppx_expect.
+ (enabled_if (>= %{ocaml_version} 4.14.0))
  (inline_tests)
  (preprocess
   (pps ppx_expect ppx_deriving.make ppx_deriving_yojson lwt_ppx))


### PR DESCRIPTION
Each commit should be self explanatory @sim642 

My intention is to make a new release 1.1 of this package that supports OCaml 4.11 onwards. We might need to constrain older versions of earlybird away from using this new version, I'll rely on the opam repo CI to discover that.